### PR TITLE
Small refactorings

### DIFF
--- a/examples/proxy/src/main.rs
+++ b/examples/proxy/src/main.rs
@@ -67,22 +67,9 @@ where
                             return Ok(server_socket);
                         }
                         Err(e) => {
-                            // Unix error codes.
-                            let status = match e.raw_os_error() {
-                                // ENETUNREACH
-                                Some(101) => socksv5::v5::SocksV5RequestStatus::NetworkUnreachable,
-                                // ETIMEDOUT
-                                Some(110) => socksv5::v5::SocksV5RequestStatus::TtlExpired,
-                                // ECONNREFUSED
-                                Some(111) => socksv5::v5::SocksV5RequestStatus::ConnectionRefused,
-                                // EHOSTUNREACH
-                                Some(113) => socksv5::v5::SocksV5RequestStatus::HostUnreachable,
-                                // Unhandled error code
-                                _ => socksv5::v5::SocksV5RequestStatus::ServerFailure,
-                            };
                             socksv5::v5::write_request_status(
                                 &mut writer,
-                                status,
+                                socksv5::v5::SocksV5RequestStatus::from_io_error(e),
                                 socksv5::v5::SocksV5Host::Ipv4([0, 0, 0, 0]),
                                 0,
                             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,5 @@ where
 {
     let mut version = [0u8];
     stream.read_exact(&mut version).await?;
-    Ok(SocksVersion::from_u8(version[0])
-        .ok_or_else(|| SocksVersionError::InvalidVersion(version[0]))?)
+    SocksVersion::from_u8(version[0]).ok_or_else(|| SocksVersionError::InvalidVersion(version[0]))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,16 @@
-#[cfg(not(feature = "tokio"))]
-use futures::io::{AsyncRead, AsyncReadExt};
 use thiserror::Error;
-#[cfg(feature = "tokio")]
-use tokio_compat::io::{AsyncRead, AsyncReadExt};
+
+use crate::io::*;
 
 pub mod v4;
 pub mod v5;
+
+pub(crate) mod io {
+    #[cfg(not(feature = "tokio"))]
+    pub use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+    #[cfg(feature = "tokio")]
+    pub use tokio_compat::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum SocksVersion {

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -1,14 +1,12 @@
 use byteorder::{BigEndian, ByteOrder};
-#[cfg(not(feature = "tokio"))]
-use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use thiserror::Error;
-#[cfg(feature = "tokio")]
-use tokio_compat::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+pub use types::*;
+
+use crate::io::*;
+use crate::SocksVersion;
 
 mod types;
-
-use crate::SocksVersion;
-pub use types::*;
 
 #[derive(Debug, Error)]
 pub enum SocksV4RequestError {

--- a/src/v5/client_commands.rs
+++ b/src/v5/client_commands.rs
@@ -1,10 +1,7 @@
 use byteorder::{ByteOrder, NetworkEndian};
-#[cfg(not(feature = "tokio"))]
-use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use thiserror::Error;
-#[cfg(feature = "tokio")]
-use tokio_compat::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
+use crate::io::*;
 use crate::v5::{
     SocksV5AddressType, SocksV5Command, SocksV5Host, SocksV5RequestError, SocksV5RequestStatus,
 };

--- a/src/v5/client_commands.rs
+++ b/src/v5/client_commands.rs
@@ -110,24 +110,7 @@ where
         ))
     })?;
 
-    let host = match atyp {
-        SocksV5AddressType::Ipv4 => {
-            let mut host = [0u8; 4];
-            reader.read_exact(&mut host).await?;
-            SocksV5Host::Ipv4(host)
-        }
-        SocksV5AddressType::Ipv6 => {
-            let mut host = [0u8; 16];
-            reader.read_exact(&mut host).await?;
-            SocksV5Host::Ipv6(host)
-        }
-        SocksV5AddressType::Domain => {
-            reader.read_exact(&mut buf[0..1]).await?;
-            let mut domain = vec![0u8; buf[0] as usize];
-            reader.read_exact(&mut domain).await?;
-            SocksV5Host::Domain(domain)
-        }
-    };
+    let host = SocksV5Host::read(&mut reader, atyp).await?;
 
     reader.read_exact(&mut buf).await?;
     let port = NetworkEndian::read_u16(&buf);

--- a/src/v5/handshake.rs
+++ b/src/v5/handshake.rs
@@ -1,9 +1,6 @@
-#[cfg(not(feature = "tokio"))]
-use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use thiserror::Error;
-#[cfg(feature = "tokio")]
-use tokio_compat::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
+use crate::io::*;
 use crate::v5::SocksV5AuthMethod;
 use crate::SocksVersion;
 

--- a/src/v5/hosts.rs
+++ b/src/v5/hosts.rs
@@ -24,6 +24,14 @@ impl SocksV5Host {
     pub fn is_domain(&self) -> bool {
         matches!(self, SocksV5Host::Domain(_))
     }
+
+    pub(crate) fn repr_len(&self) -> usize {
+        match self {
+            SocksV5Host::Domain(domain) => 1 + domain.len(),
+            SocksV5Host::Ipv4(_) => 4,
+            SocksV5Host::Ipv6(_) => 16,
+        }
+    }
 }
 
 impl From<[u8; 4]> for SocksV5Host {

--- a/src/v5/hosts.rs
+++ b/src/v5/hosts.rs
@@ -101,7 +101,7 @@ impl<'a> TryFrom<&'a SocksV5Host> for Ipv4Addr {
 
     fn try_from(host: &'a SocksV5Host) -> Result<Self, Self::Error> {
         match host {
-            SocksV5Host::Ipv4(octets) => Ok(octets.clone().into()),
+            SocksV5Host::Ipv4(octets) => Ok((*octets).into()),
             _ => Err(()),
         }
     }
@@ -123,7 +123,7 @@ impl<'a> TryFrom<&'a SocksV5Host> for Ipv6Addr {
 
     fn try_from(host: &'a SocksV5Host) -> Result<Self, Self::Error> {
         match host {
-            SocksV5Host::Ipv6(octets) => Ok(octets.clone().into()),
+            SocksV5Host::Ipv6(octets) => Ok((*octets).into()),
             _ => Err(()),
         }
     }
@@ -146,8 +146,8 @@ impl<'a> TryFrom<&'a SocksV5Host> for IpAddr {
 
     fn try_from(host: &'a SocksV5Host) -> Result<Self, Self::Error> {
         match host {
-            SocksV5Host::Ipv4(octets) => Ok(octets.clone().into()),
-            SocksV5Host::Ipv6(octets) => Ok(octets.clone().into()),
+            SocksV5Host::Ipv4(octets) => Ok((*octets).into()),
+            SocksV5Host::Ipv6(octets) => Ok((*octets).into()),
             _ => Err(()),
         }
     }

--- a/src/v5/mod.rs
+++ b/src/v5/mod.rs
@@ -1,20 +1,18 @@
 use byteorder::{ByteOrder, NetworkEndian};
-#[cfg(not(feature = "tokio"))]
-use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use thiserror::Error;
-#[cfg(feature = "tokio")]
-use tokio_compat::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+pub use client_commands::*;
+pub use handshake::*;
+pub use hosts::*;
+pub use types::*;
+
+use crate::io::*;
+use crate::SocksVersion;
 
 mod client_commands;
 mod handshake;
 mod hosts;
 mod types;
-
-use crate::SocksVersion;
-pub use client_commands::*;
-pub use handshake::*;
-pub use hosts::*;
-pub use types::*;
 
 #[derive(Debug, Error)]
 pub enum SocksV5RequestError {

--- a/src/v5/mod.rs
+++ b/src/v5/mod.rs
@@ -118,14 +118,7 @@ pub async fn write_request_status<Writer>(
 where
     Writer: AsyncWrite + Unpin,
 {
-    let mut buf = vec![
-        0u8;
-        6 + match &host {
-            SocksV5Host::Ipv4(_) => 4,
-            SocksV5Host::Ipv6(_) => 16,
-            SocksV5Host::Domain(d) => 1 + d.len(),
-        }
-    ];
+    let mut buf = vec![0u8; 6 + host.repr_len()];
     buf[0] = SocksVersion::V5.to_u8();
     buf[1] = status.to_u8();
     let idx = match &host {
@@ -147,8 +140,7 @@ where
         }
     };
     NetworkEndian::write_u16(&mut buf[idx..idx + 2], port);
-    writer.write_all(&buf).await?;
-    Ok(())
+    writer.write_all(&buf).await
 }
 
 #[cfg(test)]

--- a/src/v5/mod.rs
+++ b/src/v5/mod.rs
@@ -76,25 +76,7 @@ where
         ))
     })?;
 
-    let host = match atyp {
-        SocksV5AddressType::Ipv4 => {
-            let mut host = [0u8; 4];
-            reader.read_exact(&mut host).await?;
-            SocksV5Host::Ipv4(host)
-        }
-        SocksV5AddressType::Ipv6 => {
-            let mut host = [0u8; 16];
-            reader.read_exact(&mut host).await?;
-            SocksV5Host::Ipv6(host)
-        }
-        SocksV5AddressType::Domain => {
-            let mut domain_length = [0u8];
-            reader.read_exact(&mut domain_length).await?;
-            let mut domain = vec![0u8; domain_length[0] as usize];
-            reader.read_exact(&mut domain).await?;
-            SocksV5Host::Domain(domain)
-        }
-    };
+    let host = SocksV5Host::read(&mut reader, atyp).await?;
 
     let mut port = [0u8; 2];
     reader.read_exact(&mut port).await?;

--- a/src/v5/types.rs
+++ b/src/v5/types.rs
@@ -123,4 +123,25 @@ impl SocksV5RequestStatus {
             SocksV5RequestStatus::AddrtypeNotSupported => 0x08,
         }
     }
+
+    #[cfg(unix)]
+    pub fn from_io_error(e: std::io::Error) -> SocksV5RequestStatus {
+        match e.raw_os_error() {
+            // ENETUNREACH
+            Some(101) => socksv5::v5::SocksV5RequestStatus::NetworkUnreachable,
+            // ETIMEDOUT
+            Some(110) => socksv5::v5::SocksV5RequestStatus::TtlExpired,
+            // ECONNREFUSED
+            Some(111) => socksv5::v5::SocksV5RequestStatus::ConnectionRefused,
+            // EHOSTUNREACH
+            Some(113) => socksv5::v5::SocksV5RequestStatus::HostUnreachable,
+            // Unhandled error code
+            _ => socksv5::v5::SocksV5RequestStatus::ServerFailure,
+        }
+    }
+
+    #[cfg(not(unix))]
+    pub fn from_io_error(e: std::io::Error) -> SocksV5RequestStatus {
+        socksv5::v5::SocksV5RequestStatus::ServerFailure
+    }
 }


### PR DESCRIPTION
- Added `SocksV5Host.repr_len()` as discussed in #6.
- Fixed clippy warnings.
- Added `mod io` to simplify importing I/O traits.
- Extracted utility methods `SocksV5Host::read()` and `SocksV5RequestStatus::from_io_error()`.