### PR TITLE
Add Clone and Copy where possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub(crate) mod io {
     pub use tokio_compat::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SocksVersion {
     V4 = 0x04,
     V5 = 0x05,

--- a/src/v4/types.rs
+++ b/src/v4/types.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SocksV4Command {
     Connect,
     Bind,
@@ -21,7 +21,7 @@ impl SocksV4Command {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SocksV4RequestStatus {
     Granted,
     /// Also known as Refused

--- a/src/v5/types.rs
+++ b/src/v5/types.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SocksV5AuthMethod {
     Noauth,
     Gssapi,
@@ -29,7 +29,7 @@ impl SocksV5AuthMethod {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SocksV5Command {
     Connect,
     Bind,
@@ -55,7 +55,7 @@ impl SocksV5Command {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SocksV5AddressType {
     Ipv4,
     Domain,
@@ -81,7 +81,7 @@ impl SocksV5AddressType {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SocksV5RequestStatus {
     Success,
     ServerFailure,


### PR DESCRIPTION
This makes it a bit more ergonomic in the consuming code to copy the response status, for example, for logging or other diagnostic purposes.